### PR TITLE
fix: change transparent color to 0,0,0,0 to avoid the color influence to the model

### DIFF
--- a/tha3/util.py
+++ b/tha3/util.py
@@ -144,6 +144,13 @@ def extract_numpy_image_from_PIL_image_with_pytorch_layout(pil_image, has_alpha=
         num_channel = 3
     image_size = pil_image.width
 
+    # search for transparent pixels(alpha==0) and change them to [0 0 0 0] to avoid the color influence to the model
+    for i, px in enumerate(pil_image.getdata()):
+        if px[3] <= 0:
+            y = i // image_size
+            x = i % image_size
+            pil_image.putpixel((x, y), (0, 0, 0, 0))
+
     raw_image = numpy.asarray(pil_image)
     image = (raw_image / 255.0).reshape(image_size, image_size, num_channel)
     image[:, :, 0:3] = numpy_srgb_to_linear(image[:, :, 0:3])


### PR DESCRIPTION
Thanks for your great work! I'm a big fan of tha2 and it is so nice to see the demo of tha3.
It took me about 2 hours to figure out why my crypko generated image will not work but the originial images in the demo work well.
Seems the transparent pixel's actual color (it has RGB though its A is 0) has a big influence on the model itself.
The images provided by your demo has [0 0 0 0] for transparent pixels, but my Photoshop prefer [255 255 255 0] as transparent, and thus the output is not acceptable.
![070S Q3D7V A8FU{}%% R_8](https://user-images.githubusercontent.com/14276008/177599174-df89d35b-14f7-4f1d-a6ab-806f1e608f90.png)
![1R_~8)G76LF~IE ~Y`9M}~C](https://user-images.githubusercontent.com/14276008/177599225-f8c347af-0c11-4829-adb7-f9affa850d9c.png)
![K}$YZ4T(M${2))){IK 2YS](https://user-images.githubusercontent.com/14276008/177599246-3dc358a4-6de7-42da-8ed5-8d279daccfa7.png)
So I add a small fix on the PIL image to purify the transparent pixels, and my input images work well.
![0I%Q$XVZ6(NSY4~FFC)QQ1P](https://user-images.githubusercontent.com/14276008/177599480-65041e89-756a-4775-be23-806c03144b52.png)
Cheers! Have a good day.